### PR TITLE
Automatic update of LCU.StateAPI to 1.273.20155.12

### DIFF
--- a/state-api-user-management.csproj
+++ b/state-api-user-management.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DarkLoop.Azure.WebJobs.Authorize" Version="1.0.25-preview" />
-    <PackageReference Include="LCU.StateAPI" Version="1.264.20140.10" />
+    <PackageReference Include="LCU.StateAPI" Version="1.273.20155.12" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.1" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `LCU.StateAPI` to `1.273.20155.12` from `1.264.20140.10`
`LCU.StateAPI 1.273.20155.12` was published at `2020-06-03T19:11:39Z`, 44 minutes ago

1 project update:
Updated `state-api-user-management.csproj` to `LCU.StateAPI` `1.273.20155.12` from `1.264.20140.10`


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
